### PR TITLE
Fix：sed command to safely modify main.py using in-place editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pip install -r requirements.txt
 ### Patch dotenv
 
 ```sh
-sed -e 's/usecwd: bool = False/usecwd: bool = True/g' venv/lib/python3.11/site-packages/dotenv/main.py > venv/lib/python3.11/site-packages/dotenv/main.py
+sed -i 's/usecwd: bool = False/usecwd: bool = True/g' venv/lib/python3.11/site-packages/dotenv/main.py 
 ```
 
 ### Start server


### PR DESCRIPTION
This command is trying to modify the content of the file venv/lib/python3.11/site-packages/dotenv/main.py, specifically to replace usecwd: bool = False with usecwd: bool = True.

However, there's an error in this command: it's attempting to use output redirection > to write the modified content back to the same file. This operation typically results in the original file being emptied because output redirection > clears the target file before writing begins.

The correct approach would be to use a temporary file or the sed -i option (supported on some systems) for in-place editing: